### PR TITLE
Prevent UB when computing abs value for num opcode serialize

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -330,7 +330,7 @@ public:
 
         std::vector<unsigned char> result;
         const bool neg = value < 0;
-        uint64_t absvalue = neg ? -value : value;
+        uint64_t absvalue = neg ? ~static_cast<uint64_t>(value) + 1 : static_cast<uint64_t>(value);
 
         while(absvalue)
         {


### PR DESCRIPTION
* It seems that the original author of the snippet used glibc code:
    https://github.com/lattera/glibc/blob/master/stdlib/abs.c

However this is undefined behaviour under certain circumstances:
  https://stackoverflow.com/questions/17313579/is-there-a-safe-way-to-get-the-unsigned-absolute-value->

A relevant example can be found at :
  https://godbolt.org/z/yRwtCG

This was first reported in:
  bitcoin/bitcoin#18046