### PR TITLE
Mempool pending transactions check

### DIFF
--- a/src/tradelayer/pending.cpp
+++ b/src/tradelayer/pending.cpp
@@ -6,7 +6,9 @@
 #include "tradelayer/walletcache.h"
 
 #include "amount.h"
+#include <validation.h>
 #include "sync.h"
+#include <txmempool.h>
 #include "uint256.h"
 #include "ui_interface.h"
 
@@ -70,6 +72,32 @@ void PendingDelete(const uint256& txid)
         // if pending map is now empty following deletion, trigger a status change
         // if (my_pending.empty()) uiInterface.TLPendingChanged(false);
     }
+}
+
+/**
+ * Performs a check to ensure all pending transactions are still in the mempool.
+ *
+ * NOTE: Transactions no longer in the mempool (eg orphaned) are deleted from
+ *       the pending map and credited back to the pending tally.
+ */
+void PendingCheck()
+{
+    LOCK(cs_pending);
+
+    std::vector<uint256> vecMemPoolTxids;
+    std::vector<uint256> txidsForDeletion;
+    mempool.queryHashes(vecMemPoolTxids);
+
+    for (PendingMap::iterator it = my_pending.begin(); it != my_pending.end(); ++it) {
+        const uint256& txid = it->first;
+        if (std::find(vecMemPoolTxids.begin(), vecMemPoolTxids.end(), txid) == vecMemPoolTxids.end()) {
+            PrintToLog("WARNING: Pending transaction %s is no longer in this nodes mempool and will be discarded\n", txid.GetHex());
+            txidsForDeletion.push_back(txid);
+        }
+    }
+
+    for (auto& txid : txidsForDeletion)
+        PendingDelete(txid);
 }
 
 } // namespace mastercore

--- a/src/tradelayer/pending.h
+++ b/src/tradelayer/pending.h
@@ -24,6 +24,10 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, uint16_t
 
 /** Deletes a transaction from the pending map and credits the amount back to the pending tally for the address. */
 void PendingDelete(const uint256& txid);
+
+/** Performs a check to ensure all pending transactions are still in the mempool. */
+void PendingCheck();
+
 }
 
 /** Structure to hold information about pending transactions.

--- a/src/tradelayer/tradelayer.cpp
+++ b/src/tradelayer/tradelayer.cpp
@@ -3748,6 +3748,9 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
     // check the alert status, do we need to do anything else here?
     CheckExpiredAlerts(nBlockNow, pBlockIndex->GetBlockTime());
 
+    // check that pending transactions are still in the mempool
+    PendingCheck();
+
      // transactions were found in the block, signal the UI accordingly
      if (countMP > 0) CheckWalletUpdate(true);
 


### PR DESCRIPTION

    Performs a check to ensure all pending transactions are still in the mempool.
    
     NOTE: Transactions no longer in the mempool (eg orphaned) are deleted from
           the pending map and credited back to the pending tally.


NOTE:

Discuss. This is taken from Omnilayer, I don't know if that's the right thing to do, what do you think?
It needs testing.