### PR TITLE
Possible infinite recursion in ParseAmountContract();

### DIFF
--- a/src/tradelayer/rpcvalues.cpp
+++ b/src/tradelayer/rpcvalues.cpp
@@ -242,12 +242,6 @@ int64_t ParseAmountContract(const UniValue& value)
   return amount;
 }
 
-int64_t ParseAmountContract(const UniValue& value, int propertyType)
-{
-  bool fContract = propertyType == 3;
-  return ParseAmountContract(value, fContract);
-}
-
 uint64_t ParseLeverage(const UniValue& value)
 {
     int64_t amount = mastercore::StrToInt64(value.get_str(), true);

--- a/src/tradelayer/rpcvalues.h
+++ b/src/tradelayer/rpcvalues.h
@@ -40,7 +40,6 @@ uint32_t ParseOutputIndex(const UniValue& value);
 
 /** Parses previous transaction outputs. */
 std::vector<PrevTxsEntry> ParsePrevTxs(const UniValue& value);
-int64_t ParseAmountContract(const UniValue& value, int propertyType);
 int64_t ParseAmountContract(const UniValue& value);
 uint32_t ParseNewValues(const UniValue& value);
 uint32_t ParseContractType(const UniValue& value);


### PR DESCRIPTION
`
-int64_t ParseAmountContract(const UniValue& value, int propertyType)
-{
-  bool fContract = propertyType == 3;
-  return ParseAmountContract(value, fContract);
-}

int64_t ParseAmountContract(const UniValue& value, int propertyType);
int64_t ParseAmountContract(const UniValue& value);
`

I am not sure what the intent is here, but in any case there's a potential (actually certain) infinite loop here because there's no override with the bool argument.
Possibly we should refactor `ParseAmount` a bit to avoid this confusion.

