### PR TITLE
configure: info -- build OS, remove qt version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -825,7 +825,7 @@ fi
 BITCOIN_QT_INIT
 
 dnl sets $bitcoin_enable_qt, $bitcoin_enable_qt_test, $bitcoin_enable_qt_dbus
-BITCOIN_QT_CONFIGURE([$use_pkgconfig], [qt5])
+BITCOIN_QT_CONFIGURE([$use_pkgconfig])
 
 if test x$build_bitcoin_utils$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench = xnonononono; then
     use_boost=no
@@ -1409,7 +1409,6 @@ echo "Options used to compile and link:"
 echo "  with wallet   = $enable_wallet"
 echo "  with gui / qt = $bitcoin_enable_qt"
 if test x$bitcoin_enable_qt != xno; then
-    echo "    qt version  = $bitcoin_qt_got_major_vers"
     echo "    with qr     = $use_qr"
 fi
 echo "  with zmq      = $use_zmq"
@@ -1422,7 +1421,7 @@ echo "  debug enabled = $enable_debug"
 echo "  werror        = $enable_werror"
 echo
 echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  build os      = $build_os"
 echo
 echo "  CC            = $CC"
 echo "  CFLAGS        = $CFLAGS"


### PR DESCRIPTION
This fixes the build info after a successful configure.

For example,

`Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    with qr     = yes
  with zmq      = yes
  with test     = no
  with bench    = yes
  with upnp     = yes
  use asm       = yes
  scrypt sse2   = no
  debug enabled = no
  werror        = no

  target os     = linux
  build os      = linux-gnu

  CC            = gcc
  CFLAGS        = -g -O2
  CPPFLAGS      =  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS
  CXX           = g++ -std=c++11
  CXXFLAGS      = -g -O2 -Wall -Wextra -Wformat -Wvla -Wformat-security -Wno-unused-parameter -Wno-implicit-fallthrough
  LDFLAGS       = 
  ARFLAGS       = cr
`