### PR TITLE
Add missing QPainterPath include

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include <qt/clientmodel.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
This is needed to compile with Qt 5.15.