### PR TITLE
Add some thread names.

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -30,6 +30,7 @@
 #include <rpc/server.h>
 #include <ui_interface.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 #include <warnings.h>
 
 #ifdef ENABLE_WALLET
@@ -297,6 +298,7 @@ void BitcoinCore::initialize()
 {
     try
     {
+        util::ThreadRename("qt-init");
         qDebug() << __func__ << ": Running initialization in thread";
         bool rv = AppInitMain();
         Q_EMIT initializeResult(rv);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -44,6 +44,9 @@ ClientModel::ClientModel(OptionsModel *_optionsModel, QObject *parent) :
     pollTimer = new QTimer(this);
     connect(pollTimer, SIGNAL(timeout()), this, SLOT(updateTimer()));
     pollTimer->start(MODEL_UPDATE_DELAY);
+    QTimer::singleShot(0, pollTimer, []() {
+        util::ThreadRename("qt-clientmodl");
+    });
 
     subscribeToCoreSignals();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -17,6 +17,7 @@
 #include <rpc/server.h>
 #include <rpc/client.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 
 #include <openssl/crypto.h>
 
@@ -933,6 +934,9 @@ void RPCConsole::startExecutor()
     // Default implementation of QThread::run() simply spins up an event loop in the thread,
     // which is what we want.
     thread.start();
+    QTimer::singleShot(0, executor, []() {
+        util::ThreadRename("qt-rpcconsole");
+    });
 }
 
 void RPCConsole::on_tabWidget_currentChanged(int index)


### PR DESCRIPTION
Improve thread naming.

BTC: 
    ead771bf6fc7a4b96a03d4938796c88657c69ba6 qt: Rename qt-init thread before logging start (Hennadii Stepanov)
    ad5f614bf326d739424e8b403066f2d4275e4c1b qt: Name ClientModel timer QThread (Hennadii Stepanov)
    27dcc37d429626c75c540331340c62723529f37e qt: Name RPCConsole executor QThread (Hennadii Stepanov)
